### PR TITLE
Add manual trim workflow for labeling review

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # ATC Recorder
 
-Record and download Air Traffic Control (ATC) audio from LiveATC.net for later transcription.
+Record and download Air Traffic Control (ATC) audio from LiveATC.net, transcribe it with NVIDIA ASR services, and work with the results through a dashboard-first workflow for search, analysis, labeling, trimming, and training-data export.
 
 ## Features
 
@@ -8,8 +8,12 @@ Record and download Air Traffic Control (ATC) audio from LiveATC.net for later t
 - **Archive Download**: Download historical recordings from LiveATC archives
 - **Feed Discovery**: Automatically discover available feeds for any airport
 - **Organized Output**: Files organized by feed and date with metadata
-- **Speech-to-Text**: Automatic transcription using NVIDIA Whisper ASR (GPU required)
-- **GUI ASR Trigger**: Run ASR from the dashboard with model and preprocessing selection
+- **Automatic Transcription**: Run Whisper or Parakeet ASR on demand, in batch, or via background watchers
+- **Dashboard-First Workflow**: Use the web dashboard to browse recordings and transcripts, launch ASR jobs, review outputs, and manage training-data preparation
+- **Semantic Search and Analytics**: Search transcript segments, inspect recent flights, view position summaries, and explore embeddings when RAG services are enabled
+- **Audio Lab and Workflow Editor**: Compare preprocessing methods, save reusable presets, and execute batch audio workflows from the UI
+- **Labeling and Manual Trim**: Chunk recordings, dual-label with Whisper and Parakeet, auto-trim dialog bleed, then manually retrim and verify difficult samples
+- **Training Export**: Normalize reviewed text, export NeMo manifests, and benchmark LoRA training outputs
 
 ## Requirements
 
@@ -91,20 +95,36 @@ recordings/
 
 ```bash
 # Clone the repository
-git clone https://github.com/yourusername/atc-recorder.git
+git clone https://github.com/simpsonry1620/atc-recorder.git
 cd atc-recorder
 
-# Build the image
+# Create local env/config files
+cp .env.example .env
+
+# Build the base image
 docker compose build
 
 # List available feeds
 docker compose run --rm atc-recorder feeds list kdca
 
+# Start the dashboard
+docker compose up -d atc-dashboard
+
+# Optional: start Whisper ASR services
+docker compose --profile asr up -d
+```
+
+Common next steps:
+
+```bash
 # Record a single feed for 30 minutes
 docker compose run --rm atc-recorder record kdca1_gnd --duration 30m
 
 # Download historical archives
 docker compose --profile archive run --rm atc-archiver download kdca1_gnd --date 2026-02-01
+
+# Open the dashboard
+xdg-open "http://localhost:8050"  # Linux
 ```
 
 ## Usage
@@ -192,6 +212,18 @@ docker compose up -d atc-dashboard
 
 - Local machine: `http://localhost:8050`
 - External access: `http://<server-ip>:8050`
+
+The dashboard is the recommended operator workflow once recordings and services are running. Current tabs include:
+
+- **Overview** for service and dataset status
+- **Transcripts** for browsing recordings, transcripts, and playback
+- **Search** for semantic transcript search
+- **Flights** and **Positions** for extracted traffic/activity views
+- **Embeddings** for vector inspection
+- **Audio Lab** for preprocessing experiments and transcript comparison
+- **Workflow** for reusable audio preprocessing pipelines
+- **Labeling** for chunking, dual-ASR review, auto-trim, manual retrim, normalization, and manifest export
+- **Training** for LoRA pipeline guidance and benchmark history
 
 Quick health check:
 
@@ -321,6 +353,8 @@ If you run both Whisper and Parakeet workers, do not have both watchers transcri
 
 The worker reads optional `transcription` settings from `config.yaml` (audio preprocessing mode, pause segmentation thresholds, output format, role diarization, and cross-file stitching).
 
+The dashboard can also trigger ASR runs manually for individual recordings and compare preprocessing outputs without leaving the UI.
+
 #### Transcribe Existing Recordings
 
 Use the batch command to process files already on disk:
@@ -416,6 +450,7 @@ The project supports a Phase 1 RAG workflow aligned with NVIDIA's streaming blue
 - Segment-level embeddings and Milvus indexing
 - Time-window and feed/channel filtering during semantic search
 - Minimal HTTP search API for downstream tools
+- Dashboard views for semantic search, recent flights, and controller-position summaries
 
 #### Enable RAG in config
 

--- a/docs/chunking-pipeline.md
+++ b/docs/chunking-pipeline.md
@@ -4,7 +4,7 @@ The chunking pipeline splits raw ATC audio recordings into short (2–15 second)
 single-transmission WAV segments suitable for ASR fine-tuning.  Each chunk is
 traceable back to its source recording via a SQLite metadata store.
 
-**Source code:** `src/atc_recorder/chunker.py`, `src/atc_recorder/labeling.py`
+**Source code:** `src/atc_recorder/chunker.py`, `src/atc_recorder/labeling.py`, `src/atc_recorder/trimmer.py`, `src/atc_recorder/dashboard.py`
 
 ## Pipeline Overview
 
@@ -192,7 +192,7 @@ The CER threshold is configurable (`max_cer`, default 0.05).
 
 ### Chunk Statuses
 
-Each labeled chunk progresses through one of four states:
+Each labeled chunk progresses through one of five states:
 
 | Status     | Meaning                                      |
 |------------|----------------------------------------------|
@@ -200,6 +200,7 @@ Each labeled chunk progresses through one of four states:
 | `accepted` | CER below threshold, auto-accepted           |
 | `rejected` | CER above threshold, auto-rejected           |
 | `verified` | Manually reviewed and confirmed via dashboard |
+| `needs_retrim` | Audio needs manual boundary adjustment before final acceptance |
 
 ### Manual Verification
 
@@ -207,6 +208,8 @@ The web dashboard provides a UI for reviewing chunks:
 - Play audio
 - Compare Whisper vs. Parakeet transcripts
 - Accept, reject, or correct transcripts
+- Mark difficult chunks as `needs_retrim`
+- Open a waveform-based manual trim panel and apply new boundaries
 - Batch operations by CER range
 
 Verified and accepted chunks are exported for ASR fine-tuning manifest
@@ -217,24 +220,32 @@ generation.
 **Source code:** `src/atc_recorder/trimmer.py`
 
 After labeling, chunks often contain leading or trailing audio from
-adjacent ATC transmissions ("dialog bleed").  This occurs because:
+adjacent ATC transmissions ("dialog bleed"). This occurs because:
 
 1. VAD boundary expansion adds 0.2 s per side
 2. Ambient padding adds 0.5 s per side during extraction
 3. Back-to-back transmissions on the shared radio channel may be merged
 
-The **trim step** uses Whisper word-level timestamps to re-cut each
-chunk's audio so it aligns precisely with the transcribed text.
+The default **trim step** is local and VAD-based. It re-runs energy-based
+speech detection on each labeled WAV chunk, finds the first and last speech
+regions inside the chunk, adds small onset/offset padding, archives the
+original WAV, and overwrites the chunk with the trimmed audio.
 
 **Workflow:**
 
-1. Run Whisper on the labeled chunk to obtain word-level `start_time` /
-   `end_time` for each word.
-2. Set trim boundaries: `first_word_start − onset_pad` to
-   `last_word_end + offset_pad`.
-3. Archive the original WAV to `recordings/chunks_archive/`.
-4. Overwrite the chunk WAV with the trimmed audio.
-5. Record trim metadata in the label database.
+1. Run energy-based VAD on the chunk to find internal speech bounds.
+2. Set trim boundaries to `speech_start - onset_pad` and
+   `speech_end + offset_pad`.
+3. Skip chunks that have no detected speech, would become too short, or
+   would remove less than 50 ms of audio.
+4. Archive the original WAV to `recordings/chunks_archive/`.
+5. Overwrite the chunk WAV with the trimmed audio.
+6. Record trim metadata in the label database.
+
+If a chunk still needs cleanup after auto-trim, the dashboard review UI can
+mark it as `needs_retrim` and open a **Manual Trim** waveform panel. Manual
+trim uses user-selected boundaries instead of VAD and always trims from the
+archived original when one exists, so retrimming remains reversible.
 
 **Archiving:** Original WAVs are copied to `chunks_archive/` before
 modification, preserving the same `{feed_id}/{date}/` directory
@@ -242,10 +253,10 @@ structure.  This makes trimming fully reversible.
 
 | Parameter             | CLI flag                 | Default | Description                           |
 |-----------------------|--------------------------|---------|---------------------------------------|
-| Onset padding         | `--onset-pad`            | 0.1 s   | Padding before first word             |
-| Offset padding        | `--offset-pad`           | 0.1 s   | Padding after last word               |
+| Onset padding         | `--onset-pad`            | 0.1 s   | Padding before first detected speech  |
+| Offset padding        | `--offset-pad`           | 0.1 s   | Padding after last detected speech    |
 | Min trimmed duration  | `--min-trimmed-duration` | 0.5 s   | Skip if result would be too short     |
-| Status filter         | `--status`               | all     | Only trim accepted/verified/pending   |
+| Status filter         | `--status`               | all     | Only trim `accepted`, `verified`, or `pending` chunks |
 | Feed filter           | `--feed`                 | all     | Only trim a specific feed             |
 
 **Database columns added to `labeled_chunks`:**
@@ -258,18 +269,24 @@ structure.  This makes trimming fully reversible.
 | `original_audio_path`| TEXT | Path to archived original WAV          |
 
 Already-trimmed chunks (`trim_start_sec IS NOT NULL`) are skipped on
-re-runs, making the process idempotent.
+auto-trim re-runs, making the process idempotent.
 
 ## Entry Points
 
-| Method    | Command / Endpoint                   | Description                   |
-|-----------|--------------------------------------|-------------------------------|
-| CLI       | `atc-recorder training chunk <dir>`  | Chunk files in a directory    |
-| CLI       | `atc-recorder training label`        | Label existing chunks         |
-| CLI       | `atc-recorder training trim`         | Trim chunks to transcript     |
-| Dashboard | `POST /api/labeling/start-chunking`  | Async chunking via web UI     |
-| Dashboard | `POST /api/labeling/start-labeling`  | Async labeling via web UI     |
-| Dashboard | `POST /api/labeling/start-trimming`  | Async trimming via web UI     |
+| Method    | Command / Endpoint                         | Description                              |
+|-----------|--------------------------------------------|------------------------------------------|
+| CLI       | `atc-recorder training chunk <dir>`        | Chunk files in a directory               |
+| CLI       | `atc-recorder training label`              | Label existing chunks with dual ASR      |
+| CLI       | `atc-recorder training filter`             | Auto-accept / reject by CER threshold    |
+| CLI       | `atc-recorder training trim`               | Auto-trim labeled chunks with VAD        |
+| CLI       | `atc-recorder training normalize`          | Normalize verified / accepted text       |
+| CLI       | `atc-recorder training manifest`           | Export NeMo training manifests           |
+| Dashboard | `POST /api/labeling/start-chunking`        | Async chunking via web UI                |
+| Dashboard | `POST /api/labeling/start-labeling`        | Async dual-ASR labeling via web UI       |
+| Dashboard | `POST /api/labeling/start-trimming`        | Async VAD auto-trim via web UI           |
+| Dashboard | `POST /api/labeling/manual-trim/{chunk_id}`| Apply waveform-based manual trim         |
+| Dashboard | `POST /api/labeling/normalize`             | Normalize reviewed text in place         |
+| Dashboard | `POST /api/training/manifest`              | Export train / validation manifests      |
 
 ## Design Notes
 

--- a/src/atc_recorder/dashboard.py
+++ b/src/atc_recorder/dashboard.py
@@ -2015,6 +2015,40 @@ def create_app(config: Config) -> FastAPI:
         thread.start()
         return {"batch_id": batch_id, "total": len(untrimmed), "status": "running"}
 
+    @app.post("/api/labeling/manual-trim/{chunk_id}")
+    async def labeling_manual_trim(chunk_id: str, request: Request):
+        """Apply user-specified trim boundaries to a single chunk."""
+        body = await request.json()
+        trim_start = float(body.get("trim_start", 0))
+        trim_end = float(body.get("trim_end", 0))
+
+        if trim_start >= trim_end:
+            raise HTTPException(400, "trim_start must be less than trim_end")
+
+        ls = _get_label_store()
+        chunk = ls.get_chunk(chunk_id)
+        if chunk is None:
+            raise HTTPException(404, "Chunk not found")
+
+        tcfg = _get_training_cfg()
+        archive_dir = Path(tcfg.chunks_dir).parent / "chunks_archive"
+
+        from .trimmer import trim_chunk_manual
+
+        result = trim_chunk_manual(chunk, ls, archive_dir, trim_start, trim_end)
+
+        if result.success:
+            ls.update_status(chunk_id, "accepted", verified_by="manual_trim")
+
+        return {
+            "success": result.success,
+            "error": result.error,
+            "trimmed_duration": result.trimmed_duration,
+            "original_duration": result.original_duration,
+            "trim_start": result.trim_start_sec,
+            "trim_end": result.trim_end_sec,
+        }
+
     @app.get("/api/labeling/summary")
     async def labeling_summary():
         return _get_label_store().summary()
@@ -2104,6 +2138,10 @@ def create_app(config: Config) -> FastAPI:
             "verified_by": chunk.verified_by,
             "created_at": chunk.created_at,
             "updated_at": chunk.updated_at,
+            "trim_start_sec": chunk.trim_start_sec,
+            "trim_end_sec": chunk.trim_end_sec,
+            "original_duration": chunk.original_duration,
+            "original_audio_path": chunk.original_audio_path,
         }
 
     @app.patch("/api/labeling/chunk/{chunk_id}")
@@ -2141,7 +2179,7 @@ def create_app(config: Config) -> FastAPI:
             raise HTTPException(400, f"Unknown action: {action}")
 
     @app.get("/api/labeling/audio/{chunk_id}")
-    async def labeling_audio(chunk_id: str, denoise: bool = False):
+    async def labeling_audio(chunk_id: str, denoise: bool = False, original: bool = False):
         chunk = _get_label_store().get_chunk(chunk_id)
         if chunk is None:
             cs = _get_chunk_store()
@@ -2150,7 +2188,10 @@ def create_app(config: Config) -> FastAPI:
                 raise HTTPException(404, "Chunk not found")
             audio_path = Path(c.output_path)
         else:
-            audio_path = Path(chunk.audio_path)
+            if original and chunk.original_audio_path:
+                audio_path = Path(chunk.original_audio_path)
+            else:
+                audio_path = Path(chunk.audio_path)
         if not audio_path.exists():
             raise HTTPException(404, "Audio file not found")
 

--- a/src/atc_recorder/labeling.py
+++ b/src/atc_recorder/labeling.py
@@ -44,7 +44,7 @@ class LabeledChunk:
 class LabelStore:
     """SQLite-backed store for labeled training data."""
 
-    VALID_STATUSES = ("pending", "accepted", "rejected", "verified")
+    VALID_STATUSES = ("pending", "accepted", "rejected", "verified", "needs_retrim")
 
     def __init__(self, db_path: Path):
         self.db_path = Path(db_path)
@@ -392,6 +392,7 @@ class LabelStore:
             "accepted": by_status.get("accepted", 0),
             "rejected": by_status.get("rejected", 0),
             "verified": by_status.get("verified", 0),
+            "needs_retrim": by_status.get("needs_retrim", 0),
             "avg_cer": round(avg_cer, 4) if avg_cer is not None else 0.0,
         }
 

--- a/src/atc_recorder/static/index.html
+++ b/src/atc_recorder/static/index.html
@@ -520,7 +520,7 @@
                   <span class="flex items-center justify-center w-7 h-7 rounded-full bg-brand-900/50 text-brand-400 text-sm font-bold shrink-0">3</span>
                   <h3 class="text-sm font-semibold text-gray-200">Trim to Transcript</h3>
                 </div>
-                <p class="text-xs text-gray-500 mb-4">Remove leading/trailing dialog bleed by trimming audio to match Whisper word timestamps. Originals are archived.</p>
+                <p class="text-xs text-gray-500 mb-4">Remove leading/trailing dialog bleed using VAD speech detection. Originals are archived.</p>
                 <div class="mb-2">
                   <label class="text-xs text-gray-400 mb-1 block">Feed (optional)</label>
                   <select id="lb-trim-feed" class="input w-full text-xs h-8">
@@ -563,6 +563,7 @@
                   <span><kbd class="px-1.5 py-0.5 bg-gray-800 rounded text-gray-400 border border-gray-700">A</kbd> accept</span>
                   <span><kbd class="px-1.5 py-0.5 bg-gray-800 rounded text-gray-400 border border-gray-700">R</kbd> reject</span>
                   <span><kbd class="px-1.5 py-0.5 bg-gray-800 rounded text-gray-400 border border-gray-700">V</kbd> verify</span>
+                  <span><kbd class="px-1.5 py-0.5 bg-gray-800 rounded text-gray-400 border border-gray-700">T</kbd> retrim</span>
                 </div>
                 <div class="mt-auto">
                   <button id="lb-start-review" class="btn-primary w-full h-9 text-sm" disabled>Start Reviewing</button>
@@ -645,6 +646,7 @@
                 <option value="accepted">Accepted</option>
                 <option value="rejected">Rejected</option>
                 <option value="verified">Verified</option>
+                <option value="needs_retrim">Needs Retrim</option>
               </select>
             </div>
             <div>
@@ -710,7 +712,28 @@
               <button id="lb-verify-btn" class="btn-primary h-9">Verify</button>
               <button id="lb-accept-btn" class="btn-primary h-9">Accept</button>
               <button id="lb-reject-btn" class="btn-secondary h-9 text-red-400">Reject</button>
+              <button id="lb-retrim-btn" class="btn-secondary h-9 text-amber-400">Needs Retrim</button>
               <span id="lb-review-id" class="ml-auto text-xs text-gray-500"></span>
+            </div>
+          </div>
+
+          <!-- Manual Trim Panel -->
+          <div id="lb-manual-trim-panel" class="hidden mt-6 card">
+            <div class="flex items-center justify-between mb-3">
+              <h3 class="card-title">Manual Trim</h3>
+              <span id="lb-trim-chunk-id" class="text-xs text-gray-500"></span>
+            </div>
+            <div id="lb-waveform" class="w-full rounded-lg bg-gray-800 mb-3" style="min-height:96px"></div>
+            <div class="flex items-center gap-4 mb-3 text-xs text-gray-400">
+              <span>Start: <strong id="lb-mtrim-start" class="text-gray-200">0.00</strong>s</span>
+              <span>End: <strong id="lb-mtrim-end" class="text-gray-200">--</strong>s</span>
+              <span>Duration: <strong id="lb-mtrim-dur" class="text-gray-200">--</strong>s</span>
+            </div>
+            <div class="flex gap-2">
+              <button id="lb-mtrim-preview" class="btn-secondary h-9 text-sm">Preview Selection</button>
+              <button id="lb-mtrim-apply" class="btn-primary h-9 text-sm">Apply Trim</button>
+              <button id="lb-mtrim-cancel" class="btn-secondary h-9 text-sm">Cancel</button>
+              <span id="lb-mtrim-status" class="ml-auto text-xs text-gray-500"></span>
             </div>
           </div>
         </div>
@@ -768,6 +791,12 @@
   </div>
 
   <script src="https://unpkg.com/litegraph.js@0.7.18/build/litegraph.min.js"></script>
+  <script type="module">
+    import WaveSurfer from 'https://unpkg.com/wavesurfer.js@7/dist/wavesurfer.esm.js';
+    import RegionsPlugin from 'https://unpkg.com/wavesurfer.js@7/dist/plugins/regions.esm.js';
+    window.WaveSurfer = WaveSurfer;
+    window.WaveSurferRegions = RegionsPlugin;
+  </script>
   <script src="/static/app.js"></script>
   <script src="/static/workflow.js"></script>
   <script src="/static/labeling.js"></script>

--- a/src/atc_recorder/static/index.html
+++ b/src/atc_recorder/static/index.html
@@ -396,7 +396,7 @@
                 <path stroke-linecap="round" stroke-linejoin="round" d="M19.114 5.636a9 9 0 0 1 0 12.728M16.463 8.288a5.25 5.25 0 0 1 0 7.424M6.75 8.25l4.72-4.72a.75.75 0 0 1 1.28.53v15.88a.75.75 0 0 1-1.28.53l-4.72-4.72H4.51c-.88 0-1.704-.507-1.938-1.354A9.009 9.009 0 0 1 2.25 12c0-.83.112-1.633.322-2.396C2.806 8.756 3.63 8.25 4.51 8.25H6.75Z" />
               </svg>
               <h2 class="text-xl font-semibold text-gray-200 mb-2">Labeling Pipeline</h2>
-              <p class="text-gray-400 text-sm max-w-lg mx-auto">Chunk your recordings, label them with dual-ASR, then review and verify the results below.</p>
+              <p class="text-gray-400 text-sm max-w-lg mx-auto">Chunk recordings, label them with dual-ASR, auto-trim dialog bleed, then review, retrim, and verify the results below.</p>
             </div>
 
             <!-- Dataset overview banner -->
@@ -518,7 +518,7 @@
               <div id="lb-step-trim" class="rounded-xl border border-gray-800 bg-gray-900/50 p-5 flex flex-col">
                 <div class="flex items-center gap-2 mb-3">
                   <span class="flex items-center justify-center w-7 h-7 rounded-full bg-brand-900/50 text-brand-400 text-sm font-bold shrink-0">3</span>
-                  <h3 class="text-sm font-semibold text-gray-200">Trim to Transcript</h3>
+                  <h3 class="text-sm font-semibold text-gray-200">Auto-Trim Chunks</h3>
                 </div>
                 <p class="text-xs text-gray-500 mb-4">Remove leading/trailing dialog bleed using VAD speech detection. Originals are archived.</p>
                 <div class="mb-2">
@@ -622,7 +622,7 @@
             </div>
 
             <div class="mt-6 text-center">
-              <p class="text-xs text-gray-600">After reviewing, use the toolbar buttons to normalize text and export NeMo training manifests. See the <button class="text-brand-400 hover:underline lb-go-training">Training tab</button> for the full LoRA pipeline.</p>
+              <p class="text-xs text-gray-600">After reviewing, use the toolbar buttons to normalize text and export NeMo training manifests. See the <button class="text-brand-400 hover:underline lb-go-training">Training tab</button> for training and benchmarking steps.</p>
             </div>
           </div>
         </div>
@@ -743,11 +743,11 @@
       <section id="panel-training" class="tab-panel hidden p-6">
         <div class="card mb-6">
           <h3 class="card-title">LoRA Training Pipeline</h3>
-          <p class="text-sm text-gray-400 mt-2">Fine-tune Parakeet-TDT using LoRA adapters with labeled KDCA ATC data.</p>
+          <p class="text-sm text-gray-400 mt-2">Prepare reviewed chunks in the Labeling tab, then fine-tune Parakeet-TDT using LoRA adapters.</p>
           <div class="mt-4 grid grid-cols-1 md:grid-cols-3 gap-4">
             <div class="rounded-lg border border-gray-800 p-4">
               <h4 class="text-sm font-semibold text-gray-300 mb-2">1. Chunk &amp; Label</h4>
-              <p class="text-xs text-gray-500">Use the CLI to chunk recordings and run dual-ASR labeling, then review in the Labeling tab.</p>
+              <p class="text-xs text-gray-500">Use the Labeling tab for chunking, dual-ASR labeling, auto-trim, manual retrim, and transcript review. The CLI remains available for automation.</p>
               <code class="block mt-2 text-xs text-brand-400 bg-gray-900 rounded px-2 py-1">atc-recorder training chunk ./recordings</code>
               <code class="block mt-1 text-xs text-brand-400 bg-gray-900 rounded px-2 py-1">atc-recorder training label</code>
             </div>

--- a/src/atc_recorder/static/labeling.js
+++ b/src/atc_recorder/static/labeling.js
@@ -4,8 +4,12 @@
   "use strict";
 
   let currentReviewChunkId = null;
+  let currentReviewChunk = null;
   let perfRuns = [];
   let browseOffset = 0;
+  let wsInstance = null;
+  let wsRegions = null;
+  let trimRegion = null;
 
   // --- helpers ---
   async function api(url, opts) {
@@ -26,6 +30,7 @@
       accepted: "bg-green-900/50 text-green-400",
       rejected: "bg-red-900/50 text-red-400",
       verified: "bg-cyan-900/50 text-cyan-400",
+      needs_retrim: "bg-amber-900/50 text-amber-400",
     };
     const cls = colors[status] || "bg-gray-700 text-gray-300";
     return `<span class="px-2 py-0.5 rounded text-xs ${cls}">${status}</span>`;
@@ -286,13 +291,17 @@
 
       const cards = document.getElementById("lb-summary");
       if (!cards) return;
-      cards.innerHTML = [
+      const items = [
         { label: "Total", value: s.total, cls: "" },
         { label: "Pending", value: s.pending, cls: "text-gray-400" },
         { label: "Accepted", value: s.accepted, cls: "text-green-400" },
         { label: "Rejected", value: s.rejected, cls: "text-red-400" },
         { label: "Verified", value: s.verified, cls: "text-cyan-400" },
-      ]
+      ];
+      if (s.needs_retrim > 0) {
+        items.push({ label: "Needs Retrim", value: s.needs_retrim, cls: "text-amber-400" });
+      }
+      cards.innerHTML = items
         .map(
           (c) => `
         <div class="stat-card">
@@ -361,6 +370,11 @@
     try {
       const c = await api(`/api/labeling/chunk/${chunkId}`);
       currentReviewChunkId = chunkId;
+      currentReviewChunk = c;
+
+      destroyWaveform();
+      const trimPanel = document.getElementById("lb-manual-trim-panel");
+      if (trimPanel) trimPanel.classList.add("hidden");
 
       const reviewEl = document.getElementById("lb-review");
       reviewEl.classList.remove("hidden");
@@ -417,6 +431,128 @@
       }, { once: true });
     }
     audio.load();
+  }
+
+  function destroyWaveform() {
+    if (wsInstance) {
+      wsInstance.destroy();
+      wsInstance = null;
+      wsRegions = null;
+      trimRegion = null;
+    }
+  }
+
+  function initWaveform(audioUrl, existingStart, existingEnd) {
+    destroyWaveform();
+
+    if (!window.WaveSurfer || !window.WaveSurferRegions) {
+      console.warn("WaveSurfer not loaded yet");
+      return;
+    }
+
+    wsRegions = window.WaveSurferRegions.create();
+    wsInstance = window.WaveSurfer.create({
+      container: "#lb-waveform",
+      waveColor: "#6366f1",
+      progressColor: "#818cf8",
+      cursorColor: "#c7d2fe",
+      url: audioUrl,
+      height: 96,
+      barWidth: 2,
+      barGap: 1,
+      barRadius: 2,
+      plugins: [wsRegions],
+    });
+
+    wsInstance.on("ready", () => {
+      const duration = wsInstance.getDuration();
+      const rStart = existingStart != null ? existingStart : 0;
+      const rEnd = existingEnd != null ? existingEnd : duration;
+
+      trimRegion = wsRegions.addRegion({
+        start: rStart,
+        end: rEnd,
+        color: "rgba(99, 102, 241, 0.2)",
+        drag: false,
+        resize: true,
+      });
+
+      updateTrimReadouts(rStart, rEnd);
+    });
+
+    wsRegions.on("region-updated", (region) => {
+      updateTrimReadouts(region.start, region.end);
+    });
+  }
+
+  function updateTrimReadouts(start, end) {
+    const startEl = document.getElementById("lb-mtrim-start");
+    const endEl = document.getElementById("lb-mtrim-end");
+    const durEl = document.getElementById("lb-mtrim-dur");
+    if (startEl) startEl.textContent = start.toFixed(2);
+    if (endEl) endEl.textContent = end.toFixed(2);
+    if (durEl) durEl.textContent = (end - start).toFixed(2);
+  }
+
+  function openManualTrimPanel() {
+    if (!currentReviewChunkId) return;
+
+    const panel = document.getElementById("lb-manual-trim-panel");
+    const chunkLabel = document.getElementById("lb-trim-chunk-id");
+    const statusEl = document.getElementById("lb-mtrim-status");
+    if (panel) panel.classList.remove("hidden");
+    if (chunkLabel) chunkLabel.textContent = currentReviewChunkId;
+    if (statusEl) statusEl.textContent = "";
+
+    const audioUrl = `/api/labeling/audio/${currentReviewChunkId}?original=true`;
+    const c = currentReviewChunk;
+    const existingStart = c?.trim_start_sec ?? null;
+    const existingEnd = c?.trim_end_sec ?? null;
+
+    initWaveform(audioUrl, existingStart, existingEnd);
+
+    panel.scrollIntoView({ behavior: "smooth", block: "start" });
+  }
+
+  async function applyManualTrim() {
+    if (!currentReviewChunkId || !trimRegion) return;
+
+    const statusEl = document.getElementById("lb-mtrim-status");
+    const applyBtn = document.getElementById("lb-mtrim-apply");
+    if (applyBtn) applyBtn.disabled = true;
+    if (statusEl) statusEl.textContent = "Applying...";
+
+    try {
+      const r = await api(`/api/labeling/manual-trim/${currentReviewChunkId}`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          trim_start: trimRegion.start,
+          trim_end: trimRegion.end,
+        }),
+      });
+
+      if (r.success) {
+        if (statusEl) statusEl.textContent = `Trimmed to ${r.trimmed_duration.toFixed(2)}s`;
+        destroyWaveform();
+        const panel = document.getElementById("lb-manual-trim-panel");
+        if (panel) panel.classList.add("hidden");
+        loadLabelingSummary();
+        loadLabelingChunks();
+      } else {
+        if (statusEl) statusEl.textContent = `Error: ${r.error}`;
+      }
+    } catch (e) {
+      if (statusEl) statusEl.textContent = `Error: ${e.message}`;
+    } finally {
+      if (applyBtn) applyBtn.disabled = false;
+    }
+  }
+
+  function cancelManualTrim() {
+    destroyWaveform();
+    const panel = document.getElementById("lb-manual-trim-panel");
+    if (panel) panel.classList.add("hidden");
   }
 
   async function updateChunkStatus(status) {
@@ -477,7 +613,17 @@
     document.getElementById("lb-verify-btn")?.addEventListener("click", () => updateChunkStatus("verified"));
     document.getElementById("lb-accept-btn")?.addEventListener("click", () => updateChunkStatus("accepted"));
     document.getElementById("lb-reject-btn")?.addEventListener("click", () => updateChunkStatus("rejected"));
+    document.getElementById("lb-retrim-btn")?.addEventListener("click", () => {
+      updateChunkStatus("needs_retrim");
+      openManualTrimPanel();
+    });
     document.getElementById("lb-denoise-toggle")?.addEventListener("change", toggleDenoise);
+
+    document.getElementById("lb-mtrim-preview")?.addEventListener("click", () => {
+      if (trimRegion) trimRegion.play();
+    });
+    document.getElementById("lb-mtrim-apply")?.addEventListener("click", applyManualTrim);
+    document.getElementById("lb-mtrim-cancel")?.addEventListener("click", cancelManualTrim);
 
     document.getElementById("lb-accept-all")?.addEventListener("click", async () => {
       try {
@@ -552,6 +698,10 @@
       if (e.key === "a") updateChunkStatus("accepted");
       else if (e.key === "r") updateChunkStatus("rejected");
       else if (e.key === "v") updateChunkStatus("verified");
+      else if (e.key === "t") {
+        updateChunkStatus("needs_retrim");
+        openManualTrimPanel();
+      }
       else if (e.key === " ") {
         e.preventDefault();
         const audio = document.getElementById("lb-audio");

--- a/src/atc_recorder/static/labeling.js
+++ b/src/atc_recorder/static/labeling.js
@@ -5,6 +5,7 @@
 
   let currentReviewChunkId = null;
   let currentReviewChunk = null;
+  let visibleChunkIds = [];
   let perfRuns = [];
   let browseOffset = 0;
   let wsInstance = null;
@@ -355,10 +356,11 @@
         )
         .join("");
 
-      tbody.querySelectorAll(".lb-review-btn").forEach((btn) => {
-        btn.addEventListener("click", (e) => {
-          e.stopPropagation();
-          openReview(btn.dataset.id);
+      visibleChunkIds = chunks.map((c) => c.chunk_id);
+
+      tbody.querySelectorAll("tr[data-chunk-id]").forEach((row) => {
+        row.addEventListener("click", () => {
+          openReview(row.dataset.chunkId, true);
         });
       });
     } catch (e) {
@@ -366,7 +368,7 @@
     }
   }
 
-  async function openReview(chunkId) {
+  async function openReview(chunkId, autoplay) {
     try {
       const c = await api(`/api/labeling/chunk/${chunkId}`);
       currentReviewChunkId = chunkId;
@@ -379,13 +381,24 @@
       const reviewEl = document.getElementById("lb-review");
       reviewEl.classList.remove("hidden");
       reviewEl.scrollIntoView({ behavior: "smooth", block: "start" });
-      document.getElementById("lb-audio").src = `/api/labeling/audio/${chunkId}?t=${Date.now()}`;
+
+      const audioEl = document.getElementById("lb-audio");
+      audioEl.src = `/api/labeling/audio/${chunkId}?t=${Date.now()}`;
+      if (autoplay) {
+        audioEl.addEventListener("canplay", function onReady() {
+          audioEl.removeEventListener("canplay", onReady);
+          audioEl.play();
+        }, { once: true });
+      }
+
       document.getElementById("lb-whisper-text").textContent = c.whisper_text;
       document.getElementById("lb-parakeet-text").textContent = c.parakeet_text;
       document.getElementById("lb-verified-text").value =
         c.verified_text || c.consensus_text || c.whisper_text;
       document.getElementById("lb-review-id").textContent =
         `${chunkId} | CER: ${(c.cer * 100).toFixed(1)}% | ${c.status}`;
+
+      highlightActiveRow(chunkId);
 
       const toggle = document.getElementById("lb-denoise-toggle");
       const statusEl = document.getElementById("lb-denoise-status");
@@ -394,6 +407,25 @@
     } catch (e) {
       console.warn("open review:", e);
     }
+  }
+
+  function highlightActiveRow(chunkId) {
+    const tbody = document.getElementById("lb-tbody");
+    if (!tbody) return;
+    tbody.querySelectorAll("tr[data-chunk-id]").forEach((row) => {
+      if (row.dataset.chunkId === chunkId) {
+        row.classList.add("bg-brand-900/30");
+      } else {
+        row.classList.remove("bg-brand-900/30");
+      }
+    });
+  }
+
+  function getNextChunkId() {
+    if (!currentReviewChunkId || visibleChunkIds.length === 0) return null;
+    const idx = visibleChunkIds.indexOf(currentReviewChunkId);
+    if (idx === -1 || idx >= visibleChunkIds.length - 1) return null;
+    return visibleChunkIds[idx + 1];
   }
 
   async function toggleDenoise() {
@@ -557,8 +589,9 @@
     if (panel) panel.classList.add("hidden");
   }
 
-  async function updateChunkStatus(status) {
+  async function updateChunkStatus(status, skipAdvance) {
     if (!currentReviewChunkId) return;
+    const nextId = skipAdvance ? null : getNextChunkId();
     const verifiedText = document.getElementById("lb-verified-text")?.value || "";
     try {
       await api(`/api/labeling/chunk/${currentReviewChunkId}`, {
@@ -568,6 +601,9 @@
       });
       loadLabelingSummary();
       loadLabelingChunks();
+      if (nextId) {
+        openReview(nextId, true);
+      }
     } catch (e) {
       console.warn("update status:", e);
     }
@@ -616,7 +652,7 @@
     document.getElementById("lb-accept-btn")?.addEventListener("click", () => updateChunkStatus("accepted"));
     document.getElementById("lb-reject-btn")?.addEventListener("click", () => updateChunkStatus("rejected"));
     document.getElementById("lb-retrim-btn")?.addEventListener("click", () => {
-      updateChunkStatus("needs_retrim");
+      updateChunkStatus("needs_retrim", true);
       openManualTrimPanel();
     });
     document.getElementById("lb-denoise-toggle")?.addEventListener("change", toggleDenoise);
@@ -701,7 +737,7 @@
       else if (e.key === "r") updateChunkStatus("rejected");
       else if (e.key === "v") updateChunkStatus("verified");
       else if (e.key === "t") {
-        updateChunkStatus("needs_retrim");
+        updateChunkStatus("needs_retrim", true);
         openManualTrimPanel();
       }
       else if (e.key === " ") {

--- a/src/atc_recorder/static/labeling.js
+++ b/src/atc_recorder/static/labeling.js
@@ -379,7 +379,7 @@
       const reviewEl = document.getElementById("lb-review");
       reviewEl.classList.remove("hidden");
       reviewEl.scrollIntoView({ behavior: "smooth", block: "start" });
-      document.getElementById("lb-audio").src = `/api/labeling/audio/${chunkId}`;
+      document.getElementById("lb-audio").src = `/api/labeling/audio/${chunkId}?t=${Date.now()}`;
       document.getElementById("lb-whisper-text").textContent = c.whisper_text;
       document.getElementById("lb-parakeet-text").textContent = c.parakeet_text;
       document.getElementById("lb-verified-text").value =
@@ -408,7 +408,7 @@
 
     if (toggle.checked) {
       if (statusEl) statusEl.textContent = "(loading...)";
-      audio.src = `/api/labeling/audio/${currentReviewChunkId}?denoise=true`;
+      audio.src = `/api/labeling/audio/${currentReviewChunkId}?denoise=true&t=${Date.now()}`;
       audio.addEventListener("canplay", function onReady() {
         audio.removeEventListener("canplay", onReady);
         if (statusEl) statusEl.textContent = "";
@@ -419,10 +419,10 @@
         audio.removeEventListener("error", onErr);
         if (statusEl) statusEl.textContent = "(denoise unavailable)";
         toggle.checked = false;
-        audio.src = `/api/labeling/audio/${currentReviewChunkId}`;
+        audio.src = `/api/labeling/audio/${currentReviewChunkId}?t=${Date.now()}`;
       }, { once: true });
     } else {
-      audio.src = `/api/labeling/audio/${currentReviewChunkId}`;
+      audio.src = `/api/labeling/audio/${currentReviewChunkId}?t=${Date.now()}`;
       if (statusEl) statusEl.textContent = "";
       audio.addEventListener("canplay", function onReady() {
         audio.removeEventListener("canplay", onReady);
@@ -537,6 +537,8 @@
         destroyWaveform();
         const panel = document.getElementById("lb-manual-trim-panel");
         if (panel) panel.classList.add("hidden");
+        const audioEl = document.getElementById("lb-audio");
+        if (audioEl) audioEl.src = `/api/labeling/audio/${currentReviewChunkId}?t=${Date.now()}`;
         loadLabelingSummary();
         loadLabelingChunks();
       } else {

--- a/src/atc_recorder/trimmer.py
+++ b/src/atc_recorder/trimmer.py
@@ -201,6 +201,96 @@ def trim_chunk(
     return result
 
 
+def trim_chunk_manual(
+    chunk: LabeledChunk,
+    label_store: LabelStore,
+    archive_dir: Path,
+    trim_start: float,
+    trim_end: float,
+    min_trimmed_duration: float = 0.3,
+) -> TrimResult:
+    """Trim a chunk using user-specified boundaries (no VAD).
+
+    If the chunk was previously trimmed, reads from the archived original
+    so the user always sets boundaries against the full audio.
+    """
+    result = TrimResult(chunk_id=chunk.chunk_id)
+
+    source_path = Path(chunk.original_audio_path) if chunk.original_audio_path else Path(chunk.audio_path)
+    audio_path = Path(chunk.audio_path)
+
+    if not source_path.exists():
+        result.error = f"source audio not found: {source_path}"
+        return result
+
+    try:
+        with wave.open(str(source_path), "rb") as wf:
+            original_duration = wf.getnframes() / wf.getframerate()
+    except Exception as exc:
+        result.error = f"cannot read WAV: {exc}"
+        return result
+
+    result.original_duration = original_duration
+
+    trim_start = max(0.0, trim_start)
+    trim_end = min(original_duration, trim_end)
+
+    if (trim_end - trim_start) < min_trimmed_duration:
+        result.error = (
+            f"trimmed duration {trim_end - trim_start:.2f}s "
+            f"below minimum {min_trimmed_duration}s"
+        )
+        return result
+
+    if trim_start >= trim_end:
+        result.error = "trim_start must be less than trim_end"
+        return result
+
+    archive_path = archive_dir / audio_path.parent.name / audio_path.name
+    if chunk.feed_id and chunk.date:
+        archive_path = archive_dir / chunk.feed_id / chunk.date / audio_path.name
+
+    if not chunk.original_audio_path:
+        try:
+            archive_path.parent.mkdir(parents=True, exist_ok=True)
+            shutil.copy2(audio_path, archive_path)
+        except Exception as exc:
+            result.error = f"archiving failed: {exc}"
+            return result
+
+    try:
+        trimmed_duration = _trim_wav(source_path, audio_path, trim_start, trim_end)
+    except Exception as exc:
+        result.error = f"trim failed: {exc}"
+        return result
+
+    actual_archive = chunk.original_audio_path or str(archive_path)
+    label_store.update_trim(
+        chunk_id=chunk.chunk_id,
+        trim_start_sec=round(trim_start, 4),
+        trim_end_sec=round(trim_end, 4),
+        original_duration=round(original_duration, 4),
+        original_audio_path=actual_archive,
+        new_duration=round(trimmed_duration, 4),
+    )
+
+    result.success = True
+    result.trim_start_sec = trim_start
+    result.trim_end_sec = trim_end
+    result.trimmed_duration = trimmed_duration
+    result.archived_path = actual_archive
+
+    logger.info(
+        "Manual trim %s: %.2fs -> %.2fs [%.2f - %.2f]",
+        audio_path.name,
+        original_duration,
+        trimmed_duration,
+        trim_start,
+        trim_end,
+    )
+    return result
+
+
 @dataclass
 class TrimBatchResult:
     """Summary of a batch trim operation."""


### PR DESCRIPTION
## Summary
- add a manual trim workflow to the labeling review UI, including waveform selection, a `needs_retrim` status, backend trim persistence, and restoring trims from archived originals
- improve the review experience with autoplay, auto-advance, and cache-busting after manual trim so updated audio reloads immediately
- refresh the README, chunking pipeline doc, and dashboard guidance so the documented workflow matches the current dashboard-first trim and retrim behavior

## Test plan
- [x] Review backend and frontend changes for the manual trim flow, including `/api/labeling/manual-trim/{chunk_id}` and the `needs_retrim` status path
- [x] Verify the dashboard copy and docs align with the implemented VAD auto-trim plus manual retrim workflow
- [ ] Run the labeling workflow in the browser against local data
- [ ] Exercise trim, retrim, autoplay, and auto-advance behavior end to end

Made with [Cursor](https://cursor.com)